### PR TITLE
fix: ParseError: 'import' and 'export' may appear only with 'sourceTy…

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,5 +31,10 @@
     "classnames": "^2.2.0",
     "lodash": "^3.10.1",
     "node-uuid": "^1.4.3"
+  },
+  "browserify": {
+    "transform": [
+      "babelify"
+    ]
   }
 }


### PR DESCRIPTION
…pe: module'


http://stackoverflow.com/questions/30386317/babelify-parseerror-on-import-module-from-node-modules